### PR TITLE
add STOPSIGNAL for anki

### DIFF
--- a/dockerfiles/anki/Dockerfile
+++ b/dockerfiles/anki/Dockerfile
@@ -28,3 +28,4 @@ FROM --platform=$BUILDPLATFORM scratch
 ENV SYNC_BASE=/data
 COPY --from=builder --chmod=0755 /usr/local/cargo/bin/anki-sync-server /
 CMD ["./anki-sync-server"]
+STOPSIGNAL SIGINT


### PR DESCRIPTION
Without this, when using docker-compose and pressing Ctrl+C it ends up hanging for 10 seconds before it sends something like SIGKILL, which finally works.