### PR TITLE
anki: move `ARG version` down

### DIFF
--- a/dockerfiles/anki/Dockerfile
+++ b/dockerfiles/anki/Dockerfile
@@ -1,7 +1,6 @@
 FROM --platform=$BUILDPLATFORM rust AS builder
 SHELL ["/bin/bash", "-uo", "pipefail", "-c"]
 
-ARG version
 ARG TARGETPLATFORM
 
 # add the rust target for the target architecture
@@ -19,6 +18,7 @@ RUN dpkg --add-architecture armhf
 # armv7 => armhf
 RUN apt-get -y update && apt-get -y install protobuf-compiler clang mold musl musl-dev musl-dev:arm64 musl-dev:armhf musl-tools
 ENV PROTOC=/usr/bin/protoc
+ARG version
 RUN echo "build anki version ${version} for $(cat /.target)"
 RUN cargo install --locked --target "$(cat /.target)" --git https://github.com/ankitects/anki.git --tag ${version} anki-sync-server
 #RUN ldd /usr/local/cargo/bin/anki-sync-server


### PR DESCRIPTION
So that changing the version does not invalidate the steps that set up dependencies