### PR TITLE
anki: create a volume

### DIFF
--- a/dockerfiles/anki/Dockerfile
+++ b/dockerfiles/anki/Dockerfile
@@ -26,5 +26,6 @@ RUN cargo install --locked --target "$(cat /.target)" --git https://github.com/a
 
 FROM --platform=$BUILDPLATFORM scratch
 ENV SYNC_BASE=/data
+VOLUME "$SYNC_BASE"
 COPY --from=builder --chmod=0755 /usr/local/cargo/bin/anki-sync-server /
 CMD ["./anki-sync-server"]


### PR DESCRIPTION
Analogous to https://github.com/ankicommunity/anki-devops-services/blob/2218ed5f857c42085fd7091ea36f5b7c73f2ffae/services/anki-sync-server/images/Dockerfile#L35

Doing `VOLUME` here does not really prevent docker-compose from overriding it. This is similar to how `EXPOSE` does not really matter for docker-compose's `ports`. But at least there will always be a volume by default, lowering chances of misconfiguring the thing and losing the data together with the container.

The only doubt I have that `SYNC_BASE` here is `ENV` and not `ARG`. Maybe it would make more sense to switch it to `ARG`. I personally can't really see a use-case for being able to overwrite the sync path *inside* the container anyways. If one wants to do something different with it, they should probably just mount a volume on top of the hardcoded path.